### PR TITLE
feat: 라벨링 생성, 선택, 삭제 기능 구현

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  semi: true,
+  jsxSingleQuote: false,
+  bracketSameLine: false,
+  singleQuote: false,
+  bracketSpacing: true,
+  trailingComma: "es5",
+  arrowParens: "avoid",
+  endOfLine: "auto",
+  printWidth: 200,
+};

--- a/src/api/getPhotoAPI.js
+++ b/src/api/getPhotoAPI.js
@@ -2,9 +2,7 @@ import axios from "axios";
 
 export default async function getPhotoAPI() {
   try {
-    const response = await axios.get(
-      "https://jsonplaceholder.typicode.com/photos/1"
-    );
+    const response = await axios.get("https://jsonplaceholder.typicode.com/photos/1");
 
     return response.data;
   } catch (error) {

--- a/src/components/Board/WorkSpace/index.js
+++ b/src/components/Board/WorkSpace/index.js
@@ -1,14 +1,151 @@
-import React from "react";
+import React, { useEffect, useState, useRef } from "react";
+import getNumberByPx from "../../../utils/getNumberByPx";
 import styled from "styled-components";
 
+const eventArray = [];
+
 export default function WorkSpace({ currentMode, image }) {
+  const [isDragStart, setIsDragStart] = useState(false);
+  const [objects, setObjects] = useState([]);
+  const [newObjectStartPoint, setNewObjectStartPoint] = useState({ startX: 0, startY: 0 });
+
+  const createDiv = useRef();
+  const objectDiv = useRef([]);
+
+  useEffect(() => {
+    const handleKeyDown = e => {
+      if (e.key === "Backspace" && currentMode === "select" && objects.length !== 0) {
+        const copiedObjects = objects.filter(object => !object.isSelected);
+        setObjects(copiedObjects);
+      }
+    };
+
+    eventArray.push(handleKeyDown);
+
+    currentMode === "select" ? window.addEventListener("keydown", handleKeyDown) : window.removeEventListener("keydown", eventArray[eventArray.length - 2]);
+  }, [currentMode]);
+
+  const handleMouseUpAndDown = e => {
+    if (currentMode === "create") {
+      if (e._reactName === "onMouseDown") {
+        setIsDragStart(true);
+        setNewObjectStartPoint({ startX: e.clientX, startY: e.clientY });
+
+        return;
+      }
+
+      const { left, top, width, height } = createDiv.current.style;
+
+      const anchors = [];
+      const { Left, Top, Width, Height } = getNumberByPx(left, top, width, height);
+
+      anchors.push({ left: Left - 8 + "px", top: Top - 8 + "px" });
+      anchors.push({ left: Left + Width / 2 - 8 + "px", top: Top - 8 + "px" });
+      anchors.push({ left: Left + Width - 8 + "px", top: Top - 8 + "px" });
+      anchors.push({ left: Left + Width - 8 + "px", top: Top + Height / 2 - 8 + "px" });
+      anchors.push({ left: Left + Width - 8 + "px", top: Top + Height - 8 + "px" });
+      anchors.push({ left: Left + Width / 2 - 8 + "px", top: Top + Height - 8 + "px" });
+      anchors.push({ left: Left - 8 + "px", top: Top + Height - 8 + "px" });
+      anchors.push({ left: Left - 8 + "px", top: Top + Height / 2 - 8 + "px" });
+
+      setIsDragStart(false);
+      setObjects([...objects, { left, top, width, height, isSelected: false, anchors }]);
+    }
+
+    if (currentMode === "select") {
+      if (e._reactName === "onMouseDown") {
+        setIsDragStart(true);
+        setNewObjectStartPoint({ startX: e.clientX, startY: e.clientY });
+
+        return;
+      }
+
+      setIsDragStart(false);
+    }
+  };
+
+  const handleMouseMove = e => {
+    if (isDragStart) {
+      if (currentMode === "create") {
+        const startX = e.clientX - newObjectStartPoint.startX < 0 ? e.clientX : newObjectStartPoint.startX;
+        const startY = e.clientY - newObjectStartPoint.startY < 0 ? e.clientY : newObjectStartPoint.startY;
+        const width = Math.abs(e.clientX - newObjectStartPoint.startX);
+        const height = Math.abs(e.clientY - newObjectStartPoint.startY);
+
+        createDiv.current.style = `left: ${startX}px; top: ${startY}px; width: ${width}px; height: ${height}px`;
+      } else {
+        objects.forEach((object, index) => {
+          if (object.isSelected) {
+            const Left = Number(object.left.slice(0, object.left.indexOf("p")));
+            const Top = Number(object.top.slice(0, object.top.indexOf("p")));
+            const startX = newObjectStartPoint.startX < e.clientX ? Left + e.clientX - newObjectStartPoint.startX + "px" : Left - (newObjectStartPoint.startX - e.clientX) + "px";
+            const startY = newObjectStartPoint.startY < e.clientY ? Top + e.clientY - newObjectStartPoint.startY + "px" : Top - (newObjectStartPoint.startY - e.clientY) + "px";
+
+            objectDiv.current[index].style = `left: ${startX}; top: ${startY}; width: ${object.width}; height: ${object.height}`;
+          }
+        });
+      }
+    }
+  };
+
+  const handleMouseClick = e => {
+    if (currentMode === "select") {
+      const copiedObjects = [...objects];
+
+      copiedObjects.forEach(object => {
+        const { Left, Top, Width, Height } = getNumberByPx(object.left, object.top, object.width, object.height);
+
+        if (e.clientX >= Left && e.clientX < Left + Width && e.clientY >= Top && e.clientY <= Top + Height) object.isSelected = !object.isSelected;
+      });
+
+      setObjects(copiedObjects);
+    }
+  };
+
   return (
     <WorkSpaceWrapper>
-      <img src={image.url} alt={image.title} />
+      {isDragStart && <div ref={createDiv} className="newObject" onMouseUp={e => handleMouseUpAndDown(e)}></div>}
+      <img src={image.url} alt={image.title} onMouseDown={e => handleMouseUpAndDown(e)} onMouseMove={e => handleMouseMove(e)} onMouseUp={e => handleMouseUpAndDown(e)} />
+      {objects.map(({ left, top, width, height, isSelected, anchors }, index) => (
+        <div ref={elem => (objectDiv.current[index] = elem)} className="object" style={{ left, top, width, height }} onClick={e => handleMouseClick(e)} onMouseDown={e => handleMouseUpAndDown(e)} key={index}>
+          {isSelected && anchors.map(({ left, top }, index) => <div className="anchor" style={{ left, top }} key={index}></div>)}
+        </div>
+      ))}
     </WorkSpaceWrapper>
   );
 }
 
 const WorkSpaceWrapper = styled.div`
   background: #ffffff 0% 0% no-repeat padding-box;
+
+  img {
+    -webkit-user-drag: none;
+  }
+
+  .object {
+    position: fixed;
+    border: 1px solid #66b5ff;
+    background: var(--unnamed-color-5668d9) 0% 0% no-repeat padding-box;
+    background: #5668d9 0% 0% no-repeat padding-box;
+    opacity: 0.2;
+    z-index: 1;
+  }
+
+  .newObject {
+    position: fixed;
+    border: 1px solid #66b5ff;
+    background: var(--unnamed-color-5668d9) 0% 0% no-repeat padding-box;
+    background: #5668d9 0% 0% no-repeat padding-box;
+    opacity: 0.2;
+  }
+
+  .anchor {
+    position: fixed;
+    width: 16px;
+    height: 16px;
+    border: 3px solid var(--unnamed-color-5668d9);
+    background: #ffffff 0% 0% no-repeat padding-box;
+    border: 3px solid #5668d9;
+    opacity: 1;
+  }
 `;

--- a/src/components/MenuBar/index.js
+++ b/src/components/MenuBar/index.js
@@ -21,4 +21,8 @@ const MenuBarWrapper = styled.div`
   height: 64px;
   background: #fcfcfc 0% 0% no-repeat padding-box;
   border: 1px solid #ebedf2;
+
+  button {
+    border: none;
+  }
 `;

--- a/src/components/TabBar/index.js
+++ b/src/components/TabBar/index.js
@@ -7,7 +7,7 @@ export default function TabBar() {
 
   return (
     <TabBarWrapper>
-      {images.map((key) => (
+      {images.map(key => (
         <button key={key}>
           <img src={tabImage[key]} alt={key} />
         </button>
@@ -28,5 +28,6 @@ const TabBarWrapper = styled.div`
     border: none;
     padding: 0;
     background: transparent;
+    float: right;
   }
 `;

--- a/src/utils/getNumberByPx.js
+++ b/src/utils/getNumberByPx.js
@@ -1,0 +1,8 @@
+export default function getNumberByPx(left, top, width, height) {
+  const Left = Number(left.slice(0, left.indexOf("p")));
+  const Top = Number(top.slice(0, top.indexOf("p")));
+  const Width = Number(width.slice(0, width.indexOf("p")));
+  const Height = Number(height.slice(0, height.indexOf("p")));
+
+  return { Left, Top, Width, Height };
+}


### PR DESCRIPTION
## 작업사항
1.  mouseDown 이벤트 실행 시 시작 지점을 따로 상태로 관리하고 mouseMove를 통해 useRef를 통해 div를 참조하여 clientX, clientY, startX, startY를 비교 연산하여 동적으로 스타일을 변경해주었고 mouseUp 이벤트가 실행되었을 때, 라벨링 객체들을 관리하는 상태값에 추가하여 라벨링 생성 기능을 구현하였습니다.

2. 라벨링 객체에 anchor 속성을 추가하여 모서리 4개와 중간지점 4개의 x, y 좌표를 저장하였고, 선택 모드에서 해당 라벨링 내부의 좌표를 클릭했을 경우에만 표시되게끔 하였습니다.

3. 라벨링 객체끼리 중첩되는 지점이 있을 경우, 해당 부분을 클릭 시 그 지점을 포함하는 모든 라벨링이 선택될 수 있게끔 하였습니다.

4. 선택 모드에서 라벨링 객체가 선택된 상태에서 백스페이스 키를 누르면 라벨링 객체를 관리하는 상태값에서 해당 라벨링을 삭제하였습니다.

## 이슈사항
- 라벨링이 만들어진 지점을 관통하는 새로운 라벨링을 만들고자 할 경우 끊김 현상이 발생하여 추후에 원인을 파악하여 문제를 해결하고자 합니다.

- 라벨링이 선택된 상태에서 마우스를 움직이면 해당 라벨링의 위치를 이동시킬 수 있지만, anchor까지는 이동이 안되는 상태이고, 아직 drop기능을 구현하지 못하여 더 고민해볼 생각입니다.